### PR TITLE
updating for newer ruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,19 +21,19 @@ CLEAN.include(
 
 require 'rake/extensiontask'
 
-spec = eval(File.read("chef-win32-api.gemspec"))
+spec = eval(File.read("chef-win32-api-universal-mingw-ucrt.gemspec"))
 
-def configure_cross_compilation(ext)
-  unless RUBY_PLATFORM =~ /mswin|mingw/
-    ext.cross_compile = true
-    ext.cross_platform = ['x64-mingw32', 'x64-mingw-ucrt']
-  end
-end
+# def configure_cross_compilation(ext)
+#   unless RUBY_PLATFORM =~ /mswin|mingw/
+#     ext.cross_compile = true
+#     ext.cross_platform = ['x64-mingw32', 'x64-mingw-ucrt']
+#   end
+# end
 
 Rake::ExtensionTask.new('win32/api', spec) do |ext|
   ext.ext_dir = 'ext/win32'
   ext.lib_dir = 'lib/win32'
-  configure_cross_compilation(ext)
+  # configure_cross_compilation(ext)
 end
 
 namespace 'test' do

--- a/chef-win32-api-universal-mingw-ucrt.gemspec
+++ b/chef-win32-api-universal-mingw-ucrt.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir['test/test*']
   spec.extensions = ['ext/win32/extconf.rb']
   spec.files      = Dir['**/*'].reject{ |f| f.include?('git') }
+  spec.platform   = Gem::Platform.new(%w(universal mingw-ucrt))
 
   if RUBY_VERSION.match?("3.0")
     spec.required_ruby_version = '~> 3.0'


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the gem to get it to install correctly for Chef-19. It shows up as a mingw32 gem and not a ucrt gem

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
